### PR TITLE
Fixing CI

### DIFF
--- a/ci/lint/shellcheck.sh
+++ b/ci/lint/shellcheck.sh
@@ -2,21 +2,25 @@
 
 set -euo pipefail
 
-ROOT="$(git rev-parse --show-toplevel)"
-cd "$ROOT"
-
+# 1. Controllo dipendenze
 if ! command -v shellcheck >/dev/null 2>&1; then
-  echo "shellcheck is not installed"
+  echo "shellcheck is not installed" >&2
   exit 1
 fi
 
-scripts="$(git ls-files '*.sh')"
+# 2. Determinazione sicura della Root
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT"
+
+# 3. Raccolta script
+scripts="$(git ls-files '*.sh' 2>/dev/null || find . -name '*.sh' -type f)"
 
 if [ -z "$scripts" ]; then
   echo "No shell scripts found"
   exit 0
 fi
 
+# 4. Esecuzione lint
 count="$(printf '%s\n' "$scripts" | wc -l | tr -d ' ')"
 printf '%s\n' "$scripts" | xargs shellcheck -S error
 echo "shellcheck passed on ${count} files"

--- a/ci/test/run-bats.sh
+++ b/ci/test/run-bats.sh
@@ -2,21 +2,21 @@
 
 set -euo pipefail
 
-ROOT="$(git rev-parse --show-toplevel)"
-cd "$ROOT"
-
-# 1. Check for bats and explicitly output to stderr
+# 1. Controllo dipendenze prima di qualsiasi operazione di file system
 if ! command -v bats >/dev/null 2>&1; then
   echo "bats is not installed" >&2
   exit 1
 fi
 
-# 2. Check for tests directory
+# Se git fallisce (ambiente test), usiamo la posizione dello script
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || (cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd))"
+cd "$ROOT"
+
+# 3. Verifica esistenza directory
 if [ ! -d "tests" ]; then
   echo "tests directory not found" >&2
   exit 1
 fi
 
-# 3. Execute tests# 3. Execute tests
-# Ensure the exit code of the final command is propagated
+# 4. Esecuzione
 exec bats -r tests/unit tests/integration


### PR DESCRIPTION
Fixed failure in CI test runners (`run-bats.sh` and lint script) when handling missing dependencies in isolated/non-Git environments.

- Move `bats` and `shellcheck` verification to the very top of scripts
- Add safe fallbacks for `git rev-parse` when executed outside a Git repo
- Route error messages to stderr (`>&2`) for correct BATS assertions
- Silence expected Git errors with `2>/dev/null`