### PR TITLE
fix(ci): improve test reliability and environment isolation

### DIFF
--- a/tests/unit/ci/lint_script.bats
+++ b/tests/unit/ci/lint_script.bats
@@ -6,7 +6,6 @@ setup() {
   FAKEBIN="$TMPDIR_TEST/bin"
   mkdir -p "$FAKEBIN"
 
-  # Linkiamo solo i comandi di sistema fissi (escluso git)
   for cmd in bash printf wc tr xargs find; do
     real_cmd="$(command -v "$cmd")"
     if [ -n "$real_cmd" ]; then

--- a/tests/unit/ci/lint_script.bats
+++ b/tests/unit/ci/lint_script.bats
@@ -5,6 +5,14 @@ setup() {
   TMPDIR_TEST="$(mktemp -d)"
   FAKEBIN="$TMPDIR_TEST/bin"
   mkdir -p "$FAKEBIN"
+
+  # Linkiamo solo i comandi di sistema fissi (escluso git)
+  for cmd in bash printf wc tr xargs find; do
+    real_cmd="$(command -v "$cmd")"
+    if [ -n "$real_cmd" ]; then
+      ln -s "$real_cmd" "$FAKEBIN/$cmd"
+    fi
+  done
 }
 
 teardown() {
@@ -12,10 +20,11 @@ teardown() {
 }
 
 @test "lint script fails when shellcheck is missing" {
+  rm -f "$FAKEBIN/git"
   cat >"$FAKEBIN/git" <<'EOF'
 #!/usr/bin/env bash
 if [ "$1" = "rev-parse" ] && [ "$2" = "--show-toplevel" ]; then
-  pwd
+  printf '%s\n' "$PWD"
   exit 0
 fi
 if [ "$1" = "ls-files" ]; then
@@ -26,16 +35,17 @@ exit 1
 EOF
   chmod +x "$FAKEBIN/git"
 
-  run env PATH="$FAKEBIN:/usr/bin:/bin" /bin/bash "$ROOT/ci/lint/shellcheck.sh" 2>&1
+  run env PATH="$FAKEBIN" /bin/bash "$ROOT/ci/lint/shellcheck.sh"
   [ "$status" -eq 1 ]
   [[ "$output" == *"shellcheck is not installed"* ]]
 }
 
 @test "lint script reports success with fake shellcheck" {
+  rm -f "$FAKEBIN/git" "$FAKEBIN/shellcheck"
   cat >"$FAKEBIN/git" <<'EOF'
 #!/usr/bin/env bash
 if [ "$1" = "rev-parse" ] && [ "$2" = "--show-toplevel" ]; then
-  pwd
+  printf '%s\n' "$PWD"
   exit 0
 fi
 if [ "$1" = "ls-files" ]; then
@@ -44,24 +54,23 @@ if [ "$1" = "ls-files" ]; then
 fi
 exit 1
 EOF
-
   cat >"$FAKEBIN/shellcheck" <<'EOF'
 #!/usr/bin/env bash
 exit 0
 EOF
-
   chmod +x "$FAKEBIN/git" "$FAKEBIN/shellcheck"
 
-  run env PATH="$FAKEBIN:/usr/bin:/bin" /bin/bash "$ROOT/ci/lint/shellcheck.sh" 2>&1
+  run env PATH="$FAKEBIN" /bin/bash "$ROOT/ci/lint/shellcheck.sh"
   [ "$status" -eq 0 ]
   [[ "$output" == *"shellcheck passed on 2 files"* ]]
 }
 
 @test "lint script exits cleanly when no shell scripts are found" {
+  rm -f "$FAKEBIN/git" "$FAKEBIN/shellcheck"
   cat >"$FAKEBIN/git" <<'EOF'
 #!/usr/bin/env bash
 if [ "$1" = "rev-parse" ] && [ "$2" = "--show-toplevel" ]; then
-  pwd
+  printf '%s\n' "$PWD"
   exit 0
 fi
 if [ "$1" = "ls-files" ]; then
@@ -69,15 +78,13 @@ if [ "$1" = "ls-files" ]; then
 fi
 exit 1
 EOF
-
   cat >"$FAKEBIN/shellcheck" <<'EOF'
 #!/usr/bin/env bash
 exit 0
 EOF
-
   chmod +x "$FAKEBIN/git" "$FAKEBIN/shellcheck"
 
-  run env PATH="$FAKEBIN:/usr/bin:/bin" /bin/bash "$ROOT/ci/lint/shellcheck.sh" 2>&1
+  run env PATH="$FAKEBIN" /bin/bash "$ROOT/ci/lint/shellcheck.sh"
   [ "$status" -eq 0 ]
   [[ "$output" == *"No shell scripts found"* ]]
 }


### PR DESCRIPTION
- Refactor test setup to use dynamic PATH isolation without polluting system binaries.
- Remove hardcoded system paths in tests to prevent "command not found" (127) and permission errors.
- Ensure safe file creation by removing stale mocks before each test execution.
- Dynamically link essential utilities (bash, wc, tr, etc.) to guarantee test determinism on CI runners.